### PR TITLE
Add sample Repair Quick Reference Guide library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# RepairQRG-
-Quick reference 
+# RepairQRG
+
+A small Python library and command line tool that provides a sample **Repair Quick
+Reference Guide**. The guide contains curated repair procedures for household
+appliances, consumer electronics, and residential HVAC systems.
+
+## Features
+
+- Categorised repair procedures with summaries, time estimates, and difficulty
+  levels.
+- Detailed step-by-step instructions with tips and supplemental notes.
+- Command line interface to browse categories, search for procedures, and print
+  detailed instructions.
+
+## Installation
+
+The project has no third-party dependencies and can be run directly with
+Python 3.11 or newer. Clone the repository and install it in editable mode:
+
+```bash
+pip install --editable .
+```
+
+## Usage
+
+List the available categories:
+
+```bash
+python -m repairqrg.cli categories
+```
+
+Show details for a specific category:
+
+```bash
+python -m repairqrg.cli category appliances
+```
+
+Search for procedures containing a keyword:
+
+```bash
+python -m repairqrg.cli search "charging"
+```
+
+Display the full procedure for the best matching result:
+
+```bash
+python -m repairqrg.cli procedure "Refrigerator"
+```
+
+Each command prints formatted output to the terminal, making it easy to share
+and adapt the information for field technicians.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "repairqrg"
+version = "0.1.0"
+description = "Sample Repair Quick Reference Guide data set and CLI"
+readme = "README.md"
+authors = [{ name = "ChatGPT" }]
+requires-python = ">=3.11"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.scripts]
+repairqrg = "repairqrg.cli:main"

--- a/repairqrg/__init__.py
+++ b/repairqrg/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for building a repair quick reference guide."""
+
+from .guide import QuickReferenceGuide
+
+__all__ = ["QuickReferenceGuide"]

--- a/repairqrg/__main__.py
+++ b/repairqrg/__main__.py
@@ -1,0 +1,7 @@
+"""Entry point for ``python -m repairqrg``."""
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover - delegated to CLI
+    raise SystemExit(main())

--- a/repairqrg/cli.py
+++ b/repairqrg/cli.py
@@ -1,0 +1,98 @@
+"""Command line interface for the Repair Quick Reference Guide."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Sequence
+
+from .guide import QuickReferenceGuide
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Browse procedures in the Repair Quick Reference Guide.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("categories", help="List all available categories")
+
+    category_parser = subparsers.add_parser(
+        "category", help="Show details for a category",
+    )
+    category_parser.add_argument("key", help="Category identifier (e.g. appliances)")
+
+    search_parser = subparsers.add_parser(
+        "search", help="Search for procedures by keyword",
+    )
+    search_parser.add_argument("phrase", help="Keyword or phrase to search for")
+
+    detail_parser = subparsers.add_parser(
+        "procedure", help="Show procedure details",
+    )
+    detail_parser.add_argument("phrase", help="Name or partial name of the procedure")
+
+    return parser
+
+
+def render_categories(guide: QuickReferenceGuide) -> str:
+    items = guide.list_categories()
+    return "\n".join(items) if items else "No categories found."
+
+
+def render_category(guide: QuickReferenceGuide, key: str) -> str:
+    description = guide.describe_category(key)
+    return description or f"No category found for '{key}'."
+
+
+def render_search_results(guide: QuickReferenceGuide, phrase: str) -> str:
+    results = guide.find_procedures(phrase)
+    if not results:
+        return f"No procedures found containing '{phrase}'."
+
+    lines = []
+    for procedure in results:
+        lines.append(f"{procedure.name} [{procedure.difficulty}]")
+        lines.append(f"  {procedure.summary}")
+    return "\n".join(lines)
+
+
+def render_procedure_detail(guide: QuickReferenceGuide, phrase: str) -> str:
+    results = guide.find_procedures(phrase)
+    if not results:
+        return f"No procedures found containing '{phrase}'."
+    if len(results) == 1:
+        return guide.describe_procedure(results[0])
+
+    # If multiple matches, show a summary list to help narrow down the query.
+    lines = [
+        "Multiple procedures matched. Please refine your search:",
+        "",
+    ]
+    for procedure in results:
+        lines.append(f"- {procedure.name}: {procedure.summary}")
+    return "\n".join(lines)
+
+
+def dispatch(args: argparse.Namespace) -> str:
+    guide = QuickReferenceGuide.from_sample_catalog()
+    if args.command == "categories":
+        return render_categories(guide)
+    if args.command == "category":
+        return render_category(guide, args.key)
+    if args.command == "search":
+        return render_search_results(guide, args.phrase)
+    if args.command == "procedure":
+        return render_procedure_detail(guide, args.phrase)
+    raise ValueError(f"Unknown command: {args.command}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    output = dispatch(args)
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/repairqrg/data.py
+++ b/repairqrg/data.py
@@ -1,0 +1,278 @@
+"""Sample quick reference data for common repairs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Sequence
+
+
+@dataclass(frozen=True)
+class RepairStep:
+    """A single step in a repair procedure."""
+
+    instruction: str
+    tips: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class RepairProcedure:
+    """Representation of a repair workflow for a specific symptom."""
+
+    name: str
+    summary: str
+    estimated_time: str
+    difficulty: str
+    tools: Sequence[str]
+    supplies: Sequence[str]
+    steps: Sequence[RepairStep]
+    notes: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class RepairCategory:
+    """Grouping of repairs by equipment type."""
+
+    name: str
+    overview: str
+    procedures: Sequence[RepairProcedure]
+
+
+def build_sample_catalog() -> Dict[str, RepairCategory]:
+    """Return a catalog with curated repair procedures."""
+
+    return {
+        "appliances": RepairCategory(
+            name="Appliances",
+            overview=(
+                "Troubleshooting steps for residential appliances covering "
+                "symptoms, tools, and procedural tips."
+            ),
+            procedures=[
+                RepairProcedure(
+                    name="Refrigerator Not Cooling",
+                    summary="Diagnose airflow, condenser, and refrigerant problems.",
+                    estimated_time="45-90 minutes",
+                    difficulty="Intermediate",
+                    tools=(
+                        "Phillips screwdriver",
+                        "Nut driver",
+                        "Multimeter",
+                        "Soft brush",
+                        "Vacuum cleaner",
+                    ),
+                    supplies=("Replacement condenser fan", "Coil cleaning spray"),
+                    steps=(
+                        RepairStep(
+                            "Confirm that the thermostat is set below 40°F and the unit has power.",
+                            tips=(
+                                "Listen for the compressor turning on and off.",
+                                "Ensure the plug is firmly seated in the outlet.",
+                            ),
+                        ),
+                        RepairStep(
+                            "Inspect condenser coils and clean any accumulated dust with the brush and vacuum.",
+                            tips=(
+                                "Unplug the appliance before cleaning.",
+                                "Clean the coils in the rear and underneath the fridge.",
+                            ),
+                        ),
+                        RepairStep(
+                            "Check the condenser fan for obstructions and verify it spins freely.",
+                            tips=("Replace the fan if the blades wobble or the motor hums loudly.",),
+                        ),
+                        RepairStep(
+                            "Test the start relay and overload protector using the multimeter.",
+                            tips=("Replace components showing infinite resistance.",),
+                        ),
+                        RepairStep(
+                            "Reassemble panels and monitor temperatures for 24 hours.",
+                            tips=("Record temperatures at 4-hour intervals to confirm stability.",),
+                        ),
+                    ),
+                    notes=(
+                        "If the compressor is not running, evaluate refrigerant pressure with certified equipment.",
+                        "Document serial numbers for warranty verification before ordering parts.",
+                    ),
+                ),
+                RepairProcedure(
+                    name="Dishwasher Leaking",
+                    summary="Identify leaks caused by seals, hoses, or incorrect loading.",
+                    estimated_time="30-60 minutes",
+                    difficulty="Beginner",
+                    tools=("Torx screwdriver", "Flashlight", "Replacement gasket"),
+                    supplies=("Dishwasher-safe cleaner", "Absorbent towels"),
+                    steps=(
+                        RepairStep(
+                            "Inspect the door gasket for tears and remove debris from the seal channel.",
+                            tips=("Allow the gasket to soak in warm water before reinstalling.",),
+                        ),
+                        RepairStep(
+                            "Verify the float switch moves freely and is not obstructed by dishes.",
+                        ),
+                        RepairStep(
+                            "Run a short cycle while observing the inlet hose and pump housing for drips.",
+                            tips=(
+                                "Keep towels around the unit to quickly soak leaks.",
+                                "Tighten hose clamps gently to avoid cracking plastic fittings.",
+                            ),
+                        ),
+                        RepairStep(
+                            "Check leveling feet to ensure the tub sits evenly and adjust as needed.",
+                        ),
+                    ),
+                    notes=(
+                        "Use manufacturer-specific gaskets for a reliable seal.",
+                        "Recommend routine cleaning cycles every 30 days to prevent buildup.",
+                    ),
+                ),
+            ],
+        ),
+        "electronics": RepairCategory(
+            name="Consumer Electronics",
+            overview="Quick diagnostics for smartphones, laptops, and televisions.",
+            procedures=[
+                RepairProcedure(
+                    name="Smartphone Won't Charge",
+                    summary="Resolve charging issues caused by cables, ports, or batteries.",
+                    estimated_time="15-45 minutes",
+                    difficulty="Beginner",
+                    tools=("Soft brush", "Plastic spudger", "Replacement charging port"),
+                    supplies=("Isopropyl alcohol", "Compressed air"),
+                    steps=(
+                        RepairStep(
+                            "Inspect the charging cable and power brick for damage and test with a known-good set.",
+                        ),
+                        RepairStep(
+                            "Use compressed air and the soft brush to clean lint from the charging port.",
+                            tips=(
+                                "Hold the phone at a downward angle to encourage debris to fall out.",
+                            ),
+                        ),
+                        RepairStep(
+                            "Enter safe mode or power cycle the phone to rule out software issues.",
+                        ),
+                        RepairStep(
+                            "Disassemble the device using the spudger to access the charging port.",
+                            tips=(
+                                "Track screw placement using a magnetic pad or template.",
+                            ),
+                        ),
+                        RepairStep(
+                            "Replace the charging port assembly, reconnecting ribbon cables securely.",
+                        ),
+                    ),
+                    notes=(
+                        "Advise the customer to test charging with multiple outlets before returning the device.",
+                        "Back up data prior to disassembly if possible.",
+                    ),
+                ),
+                RepairProcedure(
+                    name="Laptop Overheating",
+                    summary="Improve airflow and thermal efficiency for laptops running hot.",
+                    estimated_time="40-75 minutes",
+                    difficulty="Intermediate",
+                    tools=("Precision screwdriver set", "Thermal paste", "ESD wrist strap"),
+                    supplies=("Compressed air", "Lint-free cloth"),
+                    steps=(
+                        RepairStep(
+                            "Document the overheating symptoms and confirm they occur under typical workloads.",
+                        ),
+                        RepairStep(
+                            "Open the chassis and disconnect the battery using the ESD strap.",
+                        ),
+                        RepairStep(
+                            "Use compressed air to clear dust from fans, vents, and heatsinks.",
+                            tips=(
+                                "Hold the fan blades steady to avoid back-spinning the motor.",
+                            ),
+                        ),
+                        RepairStep(
+                            "Remove the heatsink, clean old thermal paste, and apply a pea-sized amount of new paste.",
+                        ),
+                        RepairStep(
+                            "Reassemble the laptop, ensuring all cables are reconnected, and run a stress test.",
+                        ),
+                    ),
+                    notes=(
+                        "Log pre- and post-repair temperatures to demonstrate improvement.",
+                        "Check for BIOS updates that improve fan curves.",
+                    ),
+                ),
+            ],
+        ),
+        "hvac": RepairCategory(
+            name="HVAC",
+            overview="Field guide for residential HVAC service calls.",
+            procedures=[
+                RepairProcedure(
+                    name="Furnace Ignition Failure",
+                    summary="Restore ignition by verifying power, sensors, and gas supply.",
+                    estimated_time="30-90 minutes",
+                    difficulty="Advanced",
+                    tools=(
+                        "Multimeter",
+                        "Manometer",
+                        "Wire brush",
+                        "Allen wrench set",
+                        "Vacuum",
+                    ),
+                    supplies=("Replacement flame sensor", "Compressed air duster"),
+                    steps=(
+                        RepairStep(
+                            "Shut off power to the furnace and remove the access panel.",
+                        ),
+                        RepairStep(
+                            "Check for diagnostic blink codes and note any error sequences.",
+                            tips=("Keep a photo log of codes for customer records.",),
+                        ),
+                        RepairStep(
+                            "Measure voltage at the control board to confirm power delivery.",
+                        ),
+                        RepairStep(
+                            "Clean or replace the flame sensor using the wire brush.",
+                        ),
+                        RepairStep(
+                            "Verify gas pressure with the manometer and relight the furnace.",
+                        ),
+                    ),
+                    notes=(
+                        "Document combustion readings before leaving the job site.",
+                        "Test the thermostat for loose connections.",
+                    ),
+                ),
+                RepairProcedure(
+                    name="Air Conditioner Low Airflow",
+                    summary="Diagnose poor airflow due to filters, coils, or blower issues.",
+                    estimated_time="25-60 minutes",
+                    difficulty="Beginner",
+                    tools=("Screwdriver", "Fin comb", "Shop vacuum"),
+                    supplies=("Replacement air filter", "Coil cleaner"),
+                    steps=(
+                        RepairStep(
+                            "Inspect and replace dirty air filters, ensuring correct orientation.",
+                        ),
+                        RepairStep(
+                            "Vacuum the evaporator coil housing and gently clean the fins with the comb.",
+                        ),
+                        RepairStep(
+                            "Check the blower wheel for debris and tighten set screws if loose.",
+                        ),
+                        RepairStep(
+                            "Confirm dampers are open and registers unobstructed throughout the home.",
+                        ),
+                    ),
+                    notes=(
+                        "Educate customers on filter replacement schedules.",
+                        "If airflow remains low, evaluate duct static pressure.",
+                    ),
+                ),
+            ],
+        ),
+    }
+
+
+def flatten_procedures(catalog: Dict[str, RepairCategory]) -> Iterable[RepairProcedure]:
+    """Yield all procedures from the provided catalog."""
+
+    for category in catalog.values():
+        yield from category.procedures

--- a/repairqrg/guide.py
+++ b/repairqrg/guide.py
@@ -1,0 +1,89 @@
+"""Core classes for interacting with the repair quick reference guide."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from .data import (
+    RepairCategory,
+    RepairProcedure,
+    build_sample_catalog,
+    flatten_procedures,
+)
+
+
+@dataclass
+class QuickReferenceGuide:
+    """Provide convenient lookup helpers for repair procedures."""
+
+    catalog: Dict[str, RepairCategory]
+
+    @classmethod
+    def from_sample_catalog(cls) -> "QuickReferenceGuide":
+        """Create a quick reference guide populated with sample data."""
+
+        return cls(build_sample_catalog())
+
+    def list_categories(self) -> Sequence[str]:
+        """Return all known category keys sorted alphabetically."""
+
+        return sorted(self.catalog.keys())
+
+    def get_category(self, key: str) -> Optional[RepairCategory]:
+        """Return a category by its identifier."""
+
+        return self.catalog.get(key.lower())
+
+    def list_procedures(self, key: str) -> Sequence[RepairProcedure]:
+        """Return all repair procedures stored under a category."""
+
+        category = self.get_category(key)
+        return list(category.procedures) if category else []
+
+    def find_procedures(self, phrase: str) -> Sequence[RepairProcedure]:
+        """Return procedures whose name or summary contains the phrase."""
+
+        if not phrase:
+            return []
+
+        phrase_lower = phrase.lower()
+        results: List[RepairProcedure] = []
+        for procedure in flatten_procedures(self.catalog):
+            if phrase_lower in procedure.name.lower() or phrase_lower in procedure.summary.lower():
+                results.append(procedure)
+        return results
+
+    def describe_procedure(self, procedure: RepairProcedure) -> str:
+        """Create a formatted summary of the provided procedure."""
+
+        lines: List[str] = []
+        lines.append(f"{procedure.name} ({procedure.difficulty})")
+        lines.append(procedure.summary)
+        lines.append(f"Estimated time: {procedure.estimated_time}")
+        if procedure.tools:
+            lines.append("Tools: " + ", ".join(procedure.tools))
+        if procedure.supplies:
+            lines.append("Supplies: " + ", ".join(procedure.supplies))
+        lines.append("")
+        for idx, step in enumerate(procedure.steps, start=1):
+            lines.append(f"{idx}. {step.instruction}")
+            for tip in step.tips:
+                lines.append(f"   - Tip: {tip}")
+        if procedure.notes:
+            lines.append("")
+            lines.append("Notes:")
+            for note in procedure.notes:
+                lines.append(f" - {note}")
+        return "\n".join(lines)
+
+    def describe_category(self, key: str) -> Optional[str]:
+        """Return a formatted description for a category key."""
+
+        category = self.get_category(key)
+        if not category:
+            return None
+        lines: List[str] = [f"{category.name}", category.overview, ""]
+        for procedure in category.procedures:
+            lines.append(f"- {procedure.name}: {procedure.summary}")
+        return "\n".join(lines)


### PR DESCRIPTION
## Summary
- add a Python package with data classes and curated sample repair procedures
- implement a command line interface for listing categories, searching, and printing procedure details
- document installation and usage steps and include packaging metadata

## Testing
- python -m repairqrg.cli categories
- python -m repairqrg.cli category electronics
- python -m repairqrg.cli procedure "Laptop"
- python -m repairqrg categories
- python -m repairqrg.cli search coil

------
https://chatgpt.com/codex/tasks/task_e_68d904e4bba88325a3cd25edf9bbc9e4